### PR TITLE
Fixes composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "type": "library",
     "version": "1.0.0",
     "require": {
-        "illuminate/filesystem": "^5.6",
-        "illuminate/translation": "^5.6",
-        "illuminate/validation": "^5.6"
+        "illuminate/filesystem": "5.6.*",
+        "illuminate/translation": "5.6.*",
+        "illuminate/validation": "5.6.*"
     },
     "require-dev": {
         "orchestra/testbench": "^3.4"


### PR DESCRIPTION
This PR addresses the way how illuminate related dependencies are declared on `composer.json`.

This change is needed because Illuminate components follow the paradigm: `paradigm.minor.patch`.